### PR TITLE
Added correct IDisposable implementation

### DIFF
--- a/TinyMCE.Blazor/Editor.razor
+++ b/TinyMCE.Blazor/Editor.razor
@@ -1,6 +1,8 @@
 ﻿@using System;
 @using Microsoft.AspNetCore.Components;
 @using Microsoft.JSInterop;
+
+@implements IDisposable
 @inject IJSRuntime JSRuntime
 
 <div>
@@ -17,9 +19,10 @@
 @code {
 
   private string _value = "";
-  private bool _ready = false;
+  private bool _initialized = false;
   private ElementReference Element;
   private Dictionary<string, object> blazorConf;
+  private DotNetObjectReference<Editor> dotNetRef;
 
   [Parameter] public string Id { get; set; } = System.Guid.NewGuid().ToString();
   [Parameter] public bool Inline { get; set; } = false;
@@ -61,22 +64,11 @@
     ValueChanged.InvokeAsync(newVal);
   }
 
-  [JSInvokable("Ready")]
-  public void Ready()
-  {
-    _ready = true;
-  }
-
   protected async Task PushValue(string nextVal)
   {
     await JSRuntime.InvokeVoidAsync("tinymceBlazorWrapper.updateValue", Id, nextVal);
   }
-
-  protected override void OnInitialized()
-  {
-    base.OnInitialized();
-  }
-
+    
   protected override async Task OnAfterRenderAsync(bool firstRender)
   {
     if (firstRender)
@@ -90,15 +82,41 @@
       Dictionary<string, object> merged = Merge(Conf, AdditionalAttributes);
       blazorConf.Add("conf", merged);
       // TBD: Load the events
-      @*foreach (KeyValuePair<string, object> kvp in AdditionalAttributes)
+        @*foreach (KeyValuePair<string, object> kvp in AdditionalAttributes)
       {
         System.Diagnostics.Debug.WriteLine($"Found: {kvp.Key} with type {kvp.Value.GetType().ToString()}");
       }*@
 
-      var dotNetReference = DotNetObjectReference.Create(this);
-      await JSRuntime.InvokeVoidAsync("tinymceBlazorWrapper.init", Element, blazorConf, dotNetReference);
+      dotNetRef = DotNetObjectReference.Create(this);
+      await JSRuntime.InvokeVoidAsync("tinymceBlazorWrapper.init", Element, blazorConf, dotNetRef);
+      _initialized = true;
     }
 
+  }
+
+  public void Dispose()
+  {
+    //IAsyncDisposable is supported from .net5
+    _ = DisposeAsync();
+  }
+
+  public async Task DisposeAsync()
+  {
+    dotNetRef?.Dispose();
+    if (_initialized) {
+      var task = JSRuntime.InvokeVoidAsync("tinymceBlazorWrapper.destroy", Element, Id);
+      try
+      {
+        await task;
+      }
+      catch
+      {
+        if ( !task.IsCanceled )
+        {
+          throw;
+        }
+      }
+    }
   }
 
   // Or new Dictionary<string, object>() { d1, d2 }

--- a/TinyMCE.Blazor/TinyMCE.Blazor.csproj
+++ b/TinyMCE.Blazor/TinyMCE.Blazor.csproj
@@ -18,12 +18,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.9"  Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.9" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.4"  Condition="'$(TargetFramework)' == 'net5.0'" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.4" Condition="'$(TargetFramework)' == 'net5.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.9" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.9" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.4" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.4" Condition="'$(TargetFramework)' == 'net5.0'" />
     <None Include="../LICENSE.txt" pack="true" PackagePath="" />
-    <None Include="../tiny-icon.png" Pack="true" PackagePath=""/>
+    <None Include="../tiny-icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/TinyMCE.Blazor/wwwroot/tinymce-blazor.js
+++ b/TinyMCE.Blazor/wwwroot/tinymce-blazor.js
@@ -37,7 +37,7 @@ const CreateScriptLoader = () => {
       cb();
     } else {
       state.listeners.push(cb);
-      if (!doc.getElementById(state.sriptId)) {
+      if (!doc.getElementById(state.scriptId)) {
         injectScript(state.scriptId, doc, url, () => {
           state.listeners.forEach((fn) => fn());
           state.scriptLoaded = true;

--- a/TinyMCE.Blazor/wwwroot/tinymce-blazor.js
+++ b/TinyMCE.Blazor/wwwroot/tinymce-blazor.js
@@ -64,7 +64,7 @@ const getTiny = () => {
 
 window.tinymceBlazorWrapper = {
   updateValue: (id, value) => {
-    if (getTiny() && getTiny().get(id).getContent() !== value) {
+    if (getTiny() && getTiny().get(id) && getTiny().get(id).getContent() !== value) {
       tinymce.get(id).setContent(value);
     }
   },
@@ -79,7 +79,6 @@ window.tinymceBlazorWrapper = {
     tinyConf.inline = blazorConf.inline;
     tinyConf.target = el;
     tinyConf.setup = (editor) => {
-      dotNetRef.invokeMethodAsync('Ready');
       editor.on('init', (e) => {
         // set the initial value on init
         dotNetRef.invokeMethodAsync('GetValue').then(value => {
@@ -100,6 +99,11 @@ window.tinymceBlazorWrapper = {
           getTiny().init(tinyConf);
         });
       }
+    }
+  },
+  destroy: (el, id) => {
+    if (getTiny() && getTiny().get(id)) {
+      getTiny().get(id).remove();
     }
   }
 }


### PR DESCRIPTION
Each Blazor component, which uses `JSRuntime`, especially `DotNetObjectReference`, should implement IDisposable.

I added IDisposable implementation on .net side and component destroy on js side.
There I primary dispose DotNetObjectReference and call remove code on js side.

I'm not sure about the part in js. I added this code to remove the element. I'm not sure if it is needed. When a component is destroyed on .net side, Blazor automatically removes the whole html markup. But maybe there is some JS objects, which needs to be cleaned?
```
  destroy: (el, id) => {
    if (getTiny() && getTiny().get(id)) {
      getTiny().get(id).remove();
    }
  }
```

It also fixes a small typo, in CreateScriptLoader which causes multiple requests to tinymce.js when there is more than one editor on-page.
