### PR TITLE
INT-2544: Fix missing reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Remove event listeners when disposing
+
 ## 0.0.5 - 2021-05-12
 ### Changed
 - Setup callback to execute after initial setup

--- a/TinyMCE.Blazor/wwwroot/tinymce-blazor.js
+++ b/TinyMCE.Blazor/wwwroot/tinymce-blazor.js
@@ -139,6 +139,7 @@ window.tinymceBlazorWrapper = {
   },
   destroy: (el, id) => {
     if (getTiny() && getTiny().get(id)) {
+      getTiny().get(id).off();
       getTiny().get(id).remove();
     }
   }


### PR DESCRIPTION
Unbinding all the events when disposing of the Editor should get rid of interop calls after the Element has been disposed