### PR TITLE
INT-2987: Upgrade to the new waluigi version to use containers when running builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('waluigi@v6.0.0-rc') _
+@Library('waluigi@v6.0.0') _
 
 standardProperties()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,29 +1,26 @@
 #!groovy
-@Library('waluigi@v3.2.0') _
+@Library('waluigi@v6.0.0-rc') _
 
 standardProperties()
 
-node("bedrock-windows-10") {
-  echo "Clean workspace"
-  cleanWs()
+tinyPods.custom([
+  [ name: 'dotnet', image: 'mcr.microsoft.com/dotnet/sdk:6.0' ]
+]) {
+  container('dotnet') {
+    stage("build") {
+      echo "Building Blazor component"
+      exec('dotnet build TinyMCE.Blazor')
+    }
 
-  stage ("Checkout SCM") {
-    checkout localBranch(scm)
-  }
+    stage("test") {
+      echo "Please add tests..."
+    }
 
-  stage("Building") {
-    echo "Building Blazor component"
-    bat 'dotnet build TinyMCE.Blazor'
-  }
-
-  stage("Testing") {
-    echo "Please add tests..."
-  }
-
-  if (isReleaseBranch()) {
-    stage("Publish") {
-      withCredentials([string(credentialsId: 'NugetApi', variable: 'TOKEN')]) {
-        bat 'dotnet nuget push "TinyMCE.Blazor\\bin\\Debug\\*.nupkg" --api-key %TOKEN% --source https://api.nuget.org/v3/index.json --skip-duplicate'
+    if (isReleaseBranch()) {
+      stage("publish") {
+        withCredentials([string(credentialsId: 'NugetApi', variable: 'NUGET_API_KEY')]) {
+          exec("dotnet nuget push \"TinyMCE.Blazor/bin/Debug/*.nupkg\" --api-key ${env.NUGET_API_KEY} --source https://api.nuget.org/v3/index.json --skip-duplicate")
+        }
       }
     }
   }


### PR DESCRIPTION
This does changes things up a bit as instead of running on Windows nodes, it'll run on the Microsoft provided docker SDK container. I had a chat to @jscasca and we believe this shouldn't cause any issues though.