### PR TITLE
Fixed issue where GetClassName would never set user defined class due…

### DIFF
--- a/TinyMCE.Blazor/Editor.razor
+++ b/TinyMCE.Blazor/Editor.razor
@@ -183,7 +183,7 @@
   // prepend FieldCssClass to user provided class name;
   private string GetClassName()
   {
-    if (Field == null)
+    if (EditContext != null && Field == null)
     {
       return string.Empty;
     }


### PR DESCRIPTION
… to Field always being null if Editor is not inside EditForm. I believe that the condition was missing as checking for Field here only makes sense if we also check that EditContent isn't null.