### PR TITLE
Updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Updated CI library to latest
-- Custom ClassName would not be used if the component was not rendered inside a EditForm.
+- Custom ClassName would not be used if the component was not rendered inside a EditForm patch contributed by Kamil Kuklinski.
 
 ## 1.0.4 - 2022-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 ### Fixed
 - Updated CI library to latest
+- Custom ClassName would not be used if the component was not rendered inside a EditForm.
 
-## 1.0.4 - 2022-0520
+## 1.0.4 - 2022-05-20
+
 ### Fixed
 - Disposing of dot net reference calls
 - `InsertContent` correct function call
 
 ## 1.0.3 - 2022-04-27
+
 ### Changed
 - Chunking size limit value
 
-## 1.0.2
+## 1.0.2 - 2022-04-08
+
 ### Added
 - `InsertContent` API to insert content at caret position
 
@@ -25,36 +30,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default cloud channel back to '6'
 - Editor not cleaning up pop-up after disposing
 
-## 1.0.1
+## 1.0.1 - 2022-03-23
+
 ### Fixed
 - Default cloud channel reverted to '5' until the release of '6'
 
-## 1.0.0
+## 1.0.0 - 2022-03-08
+
 ### Changed
 - License: Code provided under MIT license
 - Default cloud channel to '6'
 
-## 0.0.9
+## 0.0.9 - 2021-12-04
+
 ### Added
 - Support for EditContext
 
-## 0.0.8 -
+## 0.0.8 - 2021-10-13
+
 ### Added
 - ClassName parameter for outside container
 
 ## 0.0.7 - 2021-08-26
+
 ### Added
 - Disable property
 
 ## 0.0.6 - 2021-05-18
+
 ### Changed
 - Remove event listeners when disposing
 
 ## 0.0.5 - 2021-05-12
+
 ### Changed
 - Setup callback to execute after initial setup
 
 ## 0.0.4 - 2021-05-07
+
 ### Added
 - Support for text output
 - IDisposable implementation
@@ -64,13 +77,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix reference when reseting to null
 
 ## 0.0.3 - 2021-01-11
+
 ### Changed
 * Update package metadata
 
 ## 0.0.2 - 2021-01-07
+
 ### Changed
 * Update package metadata
 
-## 0.0.1 (2021-01-07)
+## 0.0.1 - 2021-01-07
+
 ### Added
 * Editor wrapper for blazor


### PR DESCRIPTION
Changes:
* Adds details about the custom `ClassName` not being applied to the wrapper if the component is not inside a EditForm. Merged in a PR that fixed that issue. https://github.com/tinymce/tinymce-blazor/pull/71
* Added release dates to all changelog releases
* Fixed a typo in the date format of the last release
* Restructured it to match what we have on other project.
