### PR TITLE
TINY-11910: Added backwards compatibility support for disabled on older tinymce versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 2.2.1 - 2025-08-04
 
 ### Fixed
-- The `Disable` and `Readonly` properties was not compatible with TinyMCE versions prior to 7.6.0.
+- The `Disable` and `Readonly` properties were not compatible with TinyMCE versions prior to 7.6.0.
 
 ## 2.2.0 - 2025-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2.2.1 - 2025-08-04
+
+### Fixed
+- The `Disable` and `Readonly` properties was not compatible with TinyMCE versions prior to 7.6.0.
+
 ## 2.2.0 - 2025-07-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2.2.1 - 2025-08-04
+## 2.2.1 - 2025-08-13
 
 ### Fixed
 - The `Disable` and `Readonly` properties were not compatible with TinyMCE versions prior to 7.6.0.

--- a/TinyMCE.Blazor/TinyMCE.Blazor.csproj
+++ b/TinyMCE.Blazor/TinyMCE.Blazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
     <PackageId>TinyMCE.Blazor</PackageId>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
     <Authors>Tiny</Authors>
     <Company>Tiny</Company>
     <PackageTags>TinyMCE;RTE;Blazor;Component;Rich;Text;Editor;rich-text-editor</PackageTags>

--- a/TinyMCE.Blazor/wwwroot/TinyMce.Blazor.lib.module.js
+++ b/TinyMCE.Blazor/wwwroot/TinyMce.Blazor.lib.module.js
@@ -10,9 +10,6 @@ const setEditorMode = (editor, mode) => {
   }
 };
 
-const setLegacyDisabledOption = (tinyConf) => {
-};
-
 const CreateScriptLoader = () => {
   let unique = 0;
 
@@ -185,13 +182,11 @@ window.tinymceBlazorWrapper = {
     }
 
     if (getTiny()) {
-      setLegacyDisabledOption(tinyConf);
       getTiny().init(tinyConf);
     } else {
       if (el && el.ownerDocument) {
         // inject tiny here
         window.tinymceBlazorLoader.load(el.ownerDocument, blazorConf.src, () => {
-          setLegacyDisabledOption(tinyConf);
           getTiny().init(tinyConf);
         });
       }

--- a/TinyMCE.Blazor/wwwroot/TinyMce.Blazor.lib.module.js
+++ b/TinyMCE.Blazor/wwwroot/TinyMce.Blazor.lib.module.js
@@ -125,11 +125,7 @@ window.tinymceBlazorWrapper = {
   updateDisabled: (id, disable) => {
     const tiny = getTiny().get(id);
     if (hasDisabledSupport(tiny)) {
-      if (tiny.options && typeof tiny.options.set === 'function') {
-        tiny.options.set('disabled', disable);
-      } else {
-        setEditorMode(tiny, disable ? 'disabled' : 'design');
-      }
+      tiny.options.set('disabled', disable);
     } else {
       setEditorMode(tiny, disable ? 'readonly' : 'design');
     }

--- a/TinyMCE.BlazorDemoApp/Components/Pages/ReadonlyDisable.razor
+++ b/TinyMCE.BlazorDemoApp/Components/Pages/ReadonlyDisable.razor
@@ -30,7 +30,7 @@
 </div>
 
 @code {
-  private bool _oldTinyMce = true;
+  private bool _oldTinyMce = false;
   private string? scriptUrl;
   private bool _disable = true;
   private bool _readonly = true;

--- a/TinyMCE.BlazorDemoApp/Components/Pages/ReadonlyDisable.razor
+++ b/TinyMCE.BlazorDemoApp/Components/Pages/ReadonlyDisable.razor
@@ -10,6 +10,7 @@
 <div class="content">
   <h3>Readonly</h3>
   <Editor
+    License="gpl"
     ApiKey="@Configuration["BlazorDemoApp:ApiKey"]"
     @bind-Readonly=_readonly
     ScriptSrc="@scriptUrl"
@@ -20,6 +21,7 @@
 <div class="content">
   <h3>Disable</h3>
   <Editor
+    License="gpl"
     ApiKey="@Configuration["BlazorDemoApp:ApiKey"]"
     @bind-Disable=_disable
     ScriptSrc="@scriptUrl"
@@ -28,7 +30,7 @@
 </div>
 
 @code {
-  private bool _oldTinyMce = false;
+  private bool _oldTinyMce = true;
   private string? scriptUrl;
   private bool _disable = true;
   private bool _readonly = true;

--- a/TinyMCE.BlazorDemoApp/Components/Pages/ReadonlyDisable.razor
+++ b/TinyMCE.BlazorDemoApp/Components/Pages/ReadonlyDisable.razor
@@ -7,16 +7,35 @@
 
 <h1>Readonly and disable</h1>
 
-<Editor
-  ApiKey="@Configuration["BlazorDemoApp:ApiKey"]"
-  @bind-Disable=_disable
-  @bind-Readonly=_readonly
-/>
-<input type="checkbox" @bind="_disable" /> disable
-<input type="checkbox" @bind="_readonly" /> readonly
+<div class="content">
+  <h3>Readonly</h3>
+  <Editor
+    ApiKey="@Configuration["BlazorDemoApp:ApiKey"]"
+    @bind-Readonly=_readonly
+    ScriptSrc="@scriptUrl"
+  />
+  <label><input type="checkbox" @bind="_readonly"> readonly</label>
+</div>
+
+<div class="content">
+  <h3>Disable</h3>
+  <Editor
+    ApiKey="@Configuration["BlazorDemoApp:ApiKey"]"
+    @bind-Disable=_disable
+    ScriptSrc="@scriptUrl"
+  />
+  <label><input type="checkbox" @bind="_disable"> disable</label>
+</div>
 
 @code {
+  private bool _oldTinyMce = false;
+  private string? scriptUrl;
   private bool _disable = true;
   private bool _readonly = true;
+
+  protected override void OnInitialized() {
+    var apiKey = Configuration["BlazorDemoApp:ApiKey"];
+    scriptUrl = _oldTinyMce ? $"https://cdn.tiny.cloud/1/{apiKey}/tinymce/7.5/tinymce.min.js" : null;
+  }
 }
 

--- a/TinyMCE.BlazorDemoApp/Properties/launchSettings.json
+++ b/TinyMCE.BlazorDemoApp/Properties/launchSettings.json
@@ -13,7 +13,7 @@
         "commandName": "Project",
         "dotnetRunMessages": true,
         "launchBrowser": true,
-        "applicationUrl": "http://0.0.0.0:5277",
+        "applicationUrl": "http://localhost:5277",
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
         }


### PR DESCRIPTION
This adds backwards compatibility with TinyMCE versions prior to 7.6.0
The `Readonly` and `Disable` properties just toggles `readonly` mode for these older versions.
Also updated the demo so it's easier to see what is going on and test older a older version of the editor by flipping a boolean.
We can't pull in semver or miniature for this since we don't have a node build system for this yet that is way more work to add. So the version if manually checked.

- [x] Bump changelog release date when merging